### PR TITLE
Added Cookie-based auth + HTTP API for user creation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "standard",
+  "rules": {
+    "no-labels": 0
+  }
+}

--- a/lib/auth/check.js
+++ b/lib/auth/check.js
@@ -2,11 +2,11 @@
 
 const bcrypt = require('bcrypt')
 
-module.exports = function buildUserChecker (server) {
+module.exports = function build (db) {
   let collection
-  var checkUserPass = function (request, username, password, callback) {
+  var checkUserPass = function (username, password, callback) {
     if (!collection) {
-      collection = server.plugins['hapi-mongodb'].db.collection('users')
+      collection = db.collection('users')
     }
     collection.findOne({ username: username }, function getUser (err, user) {
       if (err) return callback(err)
@@ -14,7 +14,7 @@ module.exports = function buildUserChecker (server) {
         return callback(null, false)
       }
       bcrypt.compare(password, user.password, (err, isValid) => {
-        callback(err, isValid, { id: user.id, name: user.name })
+        callback(err, isValid)
       })
     })
   }

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const buildCheckUsers = require('./check')
+
+exports.register = function (server, options, next) {
+  const db = server.plugins['hapi-mongodb'].db
+  const checkUser = buildCheckUsers(db)
+
+  server.route({
+    method: 'POST',
+    path: '/login',
+    config: {
+      auth: {
+        mode: 'try',
+        strategy: 'session'
+      }
+    },
+    handler: function login (request, reply) {
+      if (!request.payload) {
+        return reply('Missing username or password')
+      }
+      var username = request.payload.username
+      var password = request.payload.password
+      if (!username || !password) {
+        return reply('Missing username or password')
+      }
+
+      checkUser(username, password, function checkUser (err, isValid) {
+        if ((!err) && (isValid)) {
+          request.auth.session.set({username: 'username'})
+          return reply('Login Successful')
+        }
+        return reply('Login NOT Successful')
+      })
+    }
+  })
+
+  // No Auth required for logout
+  server.route({
+    method: 'GET',
+    path: '/logout',
+    handler: function logout (request, reply) {
+      request.auth.session.clear()
+      return reply('Logout Successful')
+    }
+  })
+
+  next()
+}
+
+exports.register.attributes = {
+  name: 'auth',
+  version: '0.0.1'
+}

--- a/lib/talks/index.js
+++ b/lib/talks/index.js
@@ -16,7 +16,8 @@ exports.register = function (server, options, next) {
     path: '/talks',
     handler: function handleTalks (request, reply) {
       return talks.list(reply)
-    }
+    },
+    config: { auth: 'simple' }
   })
 
   server.route({
@@ -28,7 +29,8 @@ exports.register = function (server, options, next) {
           title: Joi.string().min(3).required(),
           speaker: Joi.string().min(3).required()
         }
-      }
+      },
+      auth: 'simple'
     },
     handler: function addTalk (request, reply) {
       talks.put(request.payload, function wrap (err, result) {
@@ -44,7 +46,8 @@ exports.register = function (server, options, next) {
     path: '/talks/{id}',
     handler: function addTalk (request, reply) {
       return talks.getById(new ObjectID(request.params.id), reply)
-    }
+    },
+    config: { auth: 'simple' }
   })
 
   next()

--- a/lib/talks/index.js
+++ b/lib/talks/index.js
@@ -17,7 +17,11 @@ exports.register = function (server, options, next) {
     handler: function handleTalks (request, reply) {
       return talks.list(reply)
     },
-    config: { auth: 'simple' }
+    config: {
+      auth: {
+        strategy: 'session'
+      }
+    }
   })
 
   server.route({
@@ -30,7 +34,9 @@ exports.register = function (server, options, next) {
           speaker: Joi.string().min(3).required()
         }
       },
-      auth: 'simple'
+      auth: {
+        strategy: 'session'
+      }
     },
     handler: function addTalk (request, reply) {
       talks.put(request.payload, function wrap (err, result) {
@@ -47,7 +53,11 @@ exports.register = function (server, options, next) {
     handler: function addTalk (request, reply) {
       return talks.getById(new ObjectID(request.params.id), reply)
     },
-    config: { auth: 'simple' }
+    config: {
+      auth: {
+        strategy: 'session'
+      }
+    }
   })
 
   next()

--- a/lib/users/check.js
+++ b/lib/users/check.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const bcrypt = require('bcrypt')
+
+module.exports = function buildUserChecker (server) {
+  let collection
+  var checkUserPass = function (request, username, password, callback) {
+    if (!collection) {
+      collection = server.plugins['hapi-mongodb'].db.collection('users')
+    }
+    collection.findOne({ username: username }, function getUser (err, user) {
+      if (err) return callback(err)
+      if (!user) {
+        return callback(null, false)
+      }
+      bcrypt.compare(password, user.password, (err, isValid) => {
+        callback(err, isValid, { id: user.id, name: user.name })
+      })
+    })
+  }
+
+  return checkUserPass
+}

--- a/lib/users/data.js
+++ b/lib/users/data.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const bcrypt = require('bcrypt')
+
+module.exports = function build (db) {
+  const collection = db.collection('users')
+
+  return {
+    put: put,
+    list: list
+  }
+
+  function put (user, callback) {
+    bcrypt.genSalt(10, function genSalt (err, salt) {
+      if (err) return callback(err)
+      bcrypt.hash(user.password, salt, function pwdHash (err, hash) {
+        if (err) return callback(err)
+        user.password = hash
+        collection.insert(user, function wrap (err, result) {
+          if (err) { return callback(err) }
+          return callback(null, result.ops[0])
+        })
+      })
+    })
+  }
+
+  function list (callback) {
+    collection.find().toArray(function wrap (err, result) {
+      if (err) { return callback(err) }
+
+      callback(null, result)
+    })
+  }
+}

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -14,6 +14,9 @@ exports.register = function (server, options, next) {
     path: '/users',
     handler: function getAllUsers (request, reply) {
       return users.list(reply)
+    },
+    config: {
+      auth: false // NOT PROTECTED
     }
   })
 
@@ -26,7 +29,8 @@ exports.register = function (server, options, next) {
           username: Joi.string().min(3).required(),
           password: Joi.string().min(3).required()
         }
-      }
+      },
+      auth: false // NOT PROTECTED
     },
     handler: function addUser (request, reply) {
       users.put(request.payload, function wrap (err, result) {

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const Joi = require('joi')
+const buildUsers = require('./data')
+
+exports.register = function (server, options, next) {
+  server.dependency('hapi-mongodb')
+
+  const db = server.plugins['hapi-mongodb'].db
+  const users = buildUsers(db)
+
+  server.route({
+    method: 'GET',
+    path: '/users',
+    handler: function getAllUsers (request, reply) {
+      return users.list(reply)
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/users',
+    config: {
+      validate: {
+        payload: {
+          username: Joi.string().min(3).required(),
+          password: Joi.string().min(3).required()
+        }
+      }
+    },
+    handler: function addUser (request, reply) {
+      users.put(request.payload, function wrap (err, result) {
+        if (err) { return reply(err) }
+
+        reply(result).code(201)
+      })
+    }
+  })
+
+  next()
+}
+
+exports.register.attributes = {
+  name: 'users',
+  version: '0.0.1'
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bcrypt": "^0.8.5",
     "hapi": "^11.1.0",
     "hapi-auth-basic": "^4.0.0",
+    "hapi-auth-cookie": "^3.1.0",
     "hapi-mongodb": "^4.0.1",
     "inert": "^3.2.0",
     "joi": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^0.8.5",
     "hapi": "^11.1.0",
+    "hapi-auth-basic": "^4.0.0",
     "hapi-mongodb": "^4.0.1",
     "inert": "^3.2.0",
     "joi": "^7.0.0",
@@ -27,6 +29,7 @@
   "devDependencies": {
     "code": "^2.0.1",
     "lab": "^7.2.0",
+    "mongo-clean": "^1.0.0",
     "pre-commit": "^1.1.2",
     "standard": "^5.3.1"
   }

--- a/test/talks/index.js
+++ b/test/talks/index.js
@@ -13,6 +13,7 @@ const beforeEach = lab.beforeEach
 const url = require('../helper').url
 
 const talks = require('../../lib/talks')
+const testCredentials = {username: 'test', password: 'test'}
 
 describe('talks', () => {
   let server
@@ -20,20 +21,24 @@ describe('talks', () => {
   beforeEach((done) => {
     server = new Hapi.Server()
     server.connection({ port: 0 })
-    server.register([{
-      register: require('hapi-mongodb'),
-      options: {
-        url: url
-      }
-    }, talks], (err) => {
-      if (err) { return done(err) }
 
-      clean(server.plugins['hapi-mongodb'].db, done)
+    server.register(require('hapi-auth-basic'), (err) => {
+      if (err) return done(err)
+      server.auth.strategy('simple', 'basic', { validateFunc: require('../../lib/users/check')(server) })
+      server.register([{
+        register: require('hapi-mongodb'),
+        options: {
+          url: url
+        }
+      }, talks], (err) => {
+        if (err) { return done(err) }
+        clean(server.plugins['hapi-mongodb'].db, done)
+      })
     })
   })
 
   it('should GET empty /talks', (done) => {
-    server.inject('/talks', (res) => {
+    server.inject({url: '/talks', credentials: testCredentials}, (res) => {
       expect(JSON.parse(res.payload)).to.deep.equal([])
       done()
     })
@@ -47,12 +52,13 @@ describe('talks', () => {
     server.inject({
       method: 'POST',
       url: '/talks',
-      payload: expected
+      payload: expected,
+      credentials: testCredentials
     }, (res) => {
       const stored = JSON.parse(res.payload)
       expect(res.statusCode).to.equal(201)
       expect(stored).to.include(expected)
-      server.inject('/talks', (res) => {
+      server.inject({url: '/talks', credentials: testCredentials}, (res) => {
         expect(JSON.parse(res.payload)).to.deep.equal([stored])
         done()
       })
@@ -66,7 +72,8 @@ describe('talks', () => {
     server.inject({
       method: 'POST',
       url: '/talks',
-      payload: expected
+      payload: expected, credentials: testCredentials
+
     }, (res) => {
       expect(res.statusCode).to.equal(400)
       done()
@@ -80,7 +87,8 @@ describe('talks', () => {
     server.inject({
       method: 'POST',
       url: '/talks',
-      payload: expected
+      payload: expected, credentials: testCredentials
+
     }, (res) => {
       expect(res.statusCode).to.equal(400)
       done()
@@ -95,11 +103,12 @@ describe('talks', () => {
     server.inject({
       method: 'POST',
       url: '/talks',
-      payload: expected
+      payload: expected, credentials: testCredentials
+
     }, (res) => {
       const stored = JSON.parse(res.payload)
       expect(stored).to.include(expected)
-      server.inject('/talks/' + stored._id, (res) => {
+      server.inject({url: '/talks/' + stored._id, credentials: testCredentials}, (res) => {
         expect(res.statusCode).to.equal(200)
         expect(JSON.parse(res.payload)).to.deep.equal(stored)
         done()

--- a/test/talks/index.js
+++ b/test/talks/index.js
@@ -22,9 +22,17 @@ describe('talks', () => {
     server = new Hapi.Server()
     server.connection({ port: 0 })
 
-    server.register(require('hapi-auth-basic'), (err) => {
+    server.register(require('hapi-auth-cookie'), (err) => {
       if (err) return done(err)
-      server.auth.strategy('simple', 'basic', { validateFunc: require('../../lib/users/check')(server) })
+
+      // Authentication strategies
+      server.auth.strategy('session', 'cookie', true, {
+        password: 'supersecretpassword', // cookie secret
+        cookie: 'workshop-cookie', // Cookie name
+        ttl: 60 * 60 * 1000, // Set session to 1 hour
+        isSecure: false // IF NOT THE AUTH FAILS IF NOT HTTPS
+      })
+
       server.register([{
         register: require('hapi-mongodb'),
         options: {


### PR DESCRIPTION
The "talks" APIs are now protected with basic auth. 
The user data test is still missing. 
Added the "credentials" to the talks tests (it deiablle the hapi authentication strategy)
